### PR TITLE
Fix params for getOrders method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,7 @@ class Shopware {
     return this.handleRequest({
       url: 'orders/',
       method: 'GET',
-      params
+      qs: params
     }, 'data')
   }
 


### PR DESCRIPTION
All parameters for getOrder like filter and skip are send via the query parameter.

The `params` parameter doesn't exist in the request module.
So the parameters was not working at all.
See: https://github.com/request/request/tree/v2.81.0#requestoptions-callback

I replaced the `params` with `qs`