### PR TITLE
added update translations method to update multiple translations at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Find the [docs here](https://apertureless.github.io/shopware-api-client/#/) *con
   - .getTranslation(id, [callback]) 🔀 `Promise`
   - .createTranslation(id, body, [callback]) 🔀 `Promise`
   - .updateTranslation(id, body, [callback]) 🔀 `Promise`
+  - .updateTranslations(body, [callback]) 🔀 `Promise`
   - .deleteTranslation(id, [callback]) 🔀 `Promise`
 
 ## Contributing

--- a/src/index.js
+++ b/src/index.js
@@ -894,6 +894,18 @@ class Shopware {
     })
   }
 
+  updateTranslations(body) {
+    if (!body) {
+      return handleError(ERROR.MISSING_BODY)
+    }
+
+    return this.handleRequest({
+      url: `translations/`,
+      method: 'PUT',
+      body
+    })
+  }
+
   deleteTranslation(id) {
     if (!id) {
       return handleError(ERROR.MISSING_ID)


### PR DESCRIPTION
From the API documentation it is possible to update multiple translations at once. See here https://developers.shopware.com/developers-guide/rest-api/api-resource-translation/ and here https://developers.shopware.com/developers-guide/rest-api/examples/translation/