### PR TITLE
Adding a new error type / Fix Docs links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Find the [docs here](https://apertureless.github.io/shopware-api-client/#/) *con
 ## API Reference
 
 - Shopware
-  - [new Shopware([object])](#new_shopware)
+  - [new Shopware([object])](https://github.com/apertureless/shopware-api-client/tree/master/docs#new_shopware)
   - [.version([callback])](#version) 🔀 `Promise`
   - [.getArticles([callback])](#getArticles) 🔀 `Promise`
   - .getArticleByOrdernumber(ordernumber, [callback]) 🔀 `Promise`

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Find the [docs here](https://apertureless.github.io/shopware-api-client/#/) *con
 
 - Shopware
   - [new Shopware([object])](https://github.com/apertureless/shopware-api-client/tree/master/docs#new_shopware)
-  - [.version([callback])](#version) 🔀 `Promise`
-  - [.getArticles([callback])](#getArticles) 🔀 `Promise`
-  - .getArticleByOrdernumber(ordernumber, [callback]) 🔀 `Promise`
-  - [.getArticle(id, [callback])](#getArticle) 🔀 `Promise`
-  - [.deleteArticle(id, [callback])](#deleteArticle) 🔀 `Promise`
-  - [.deleteArticles(ids, [callback])](#deleteArticles) 🔀 `Promise`
-  - [.createArticle(article, [callback])](#createArticle) 🔀 `Promise`
-  - [.updateArticle(id, article, [callback])](#updateArticle) 🔀 `Promise`
+  - [.version([callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#version) 🔀 `Promise`
+  - [.getArticles([callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#getArticles) 🔀 `Promise`
+  - [.getArticleByOrdernumber(ordernumber, [callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#getArticleByOrdernumber) 🔀 `Promise`
+  - [.getArticle(id, [callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#getArticle) 🔀 `Promise`
+  - [.deleteArticle(id, [callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#deleteArticle) 🔀 `Promise`
+  - [.deleteArticles(ids, [callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#deleteArticles) 🔀 `Promise`
+  - [.createArticle(article, [callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#createArticle) 🔀 `Promise`
+  - [.updateArticle(id, article, [callback])](https://github.com/apertureless/shopware-api-client/tree/master/docs#updateArticle) 🔀 `Promise`
   - .updateArticles(articles, [callback]) 🔀 `Promise`
   - .getCategories([callback]) 🔀 `Promise`
   - .getCategory(id, [callback]) 🔀 `Promise`

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
   - [.version([callback])](#version) 🔀 `Promise`
   - [.getArticles([callback])](#getArticles) 🔀 `Promise`
   - [.getArticle(id, [callback])](#getArticle) 🔀 `Promise`
+  - [.getArticleByOrdernumber(ordernumber, [callback])](#getArticleByOrdernumber) 🔀 `Promise`
   - [.deleteArticle(id, [callback])](#deleteArticle) 🔀 `Promise`
   - [.deleteArticles(ids, [callback])](#deleteArticles) 🔀 `Promise`
   - [.createArticle(article, [callback])](#createArticle) 🔀 `Promise`
@@ -147,6 +148,18 @@ Returns an object with article data.
 | [callback] | <code>function</code> | Callback will be called with `(err, articles)` |
 
 <a name="deleteArticle"></a>
+
+### shop.getArticleByOrdernumber(ordernumber, [callback]) ⇒ <code>Promise</code>
+Returns an object with article data.
+
+**See**: https://developers.shopware.com/developers-guide/rest-api/api-resource-article/
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ordernumber | <code>string</code> | Article ordernumber |
+| [callback] | <code>function</code> | Callback will be called with `(err, articles)` |
+
+<a name="getArticleByOrdernumber"></a>
 
 ### shop.deleteArticle(id, [callback]) ⇒ <code>Promise</code>
 Deletes an article and returns it's data.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ const ERROR = {
   MISSING_BODY: {
     code: 'missing_body',
     message: 'Missing a proper `body` parameter'
+  },
+  MISSING_ORDERNUMBER: {
+    code: 'missing_ordernumber',
+    message: 'Missing `ordernumber` parameter'
   }
 }
 
@@ -80,7 +84,7 @@ class Shopware {
 
   getArticleByOrdernumber(ordernumber) {
     if (!ordernumber) {
-      return handleError(ERROR.MISSING_ID)
+      return handleError(ERROR.MISSING_ORDERNUMBER)
     }
 
     return this.handleRequest({


### PR DESCRIPTION
This PR provides following things:
- add a new error `MISSING_ORDERNUMBER` in case there is no ordernumber given in `getArticleByOrdernumber`
- Fixes the anchor links in README to docs
- adds a doc for `getArticleByOrderNumber`